### PR TITLE
Workaraound for the app stopping when API calls fail (#15)

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id":"com.tesla",
-  "version":"2.1.0",
+  "version":"2.1.1",
   "compatibility":">=2.0.2",
   "sdk": 2,
   "name":{
@@ -114,6 +114,9 @@
       },
       "class":"other",
       "capabilities":["distance", "distance_nr", "location_human", "moving", "geofences", "measure_battery"],
+	  "energy": {
+		"batteries": [ "INTERNAL" ]
+	  },
       "settings":[
         {
           "type":"group",
@@ -229,6 +232,26 @@
               "label":{
                 "en":"New password",
                 "nl":"Nieuw wachtwoord"
+              }
+            },
+            { "id":"loginRetry",
+              "type":"checkbox",
+              "label":{
+                "en":"Retry token login if API fails",
+                "nl":"Retry token login if API fails"
+              },
+              "value": true
+            },
+            { "id":"loginRetryInterval",
+              "type":"number",
+              "label":{
+                "en":"Retry token login interval (minutes)",
+                "nl":"Retry token login interval (minutes)"
+              },
+              "value": 1,
+              "attr":{
+                "min": 1,
+                "max": 1440
               }
             }
           ]

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "id":"com.tesla",
-  "version":"2.1.2",
+  "version":"2.1.3",
   "compatibility":">=2.0.2",
   "sdk": 2,
   "name":{
@@ -253,6 +253,14 @@
                "min": 1,
                "max": 1440
              }
+           },
+            { "id":"endlessRetries",
+             "type":"checkbox",
+             "label":{
+               "en":"Endless API retries",
+               "nl":"Eindeloze API-pogingen"
+             },
+             "value": false
            }
           ]
         },

--- a/drivers/ev/device.js
+++ b/drivers/ev/device.js
@@ -10,7 +10,6 @@ const maxApiErrors = 5
 let trackControllerCount = 0
 let vehicles = {}
 let geofences = {}
-let passwordAttempt = 0
 
 class Vehicle extends Homey.Device {
   onDeleted () {
@@ -117,7 +116,6 @@ class Vehicle extends Homey.Device {
 
     if (changedKeysArr.find(key => key === 'password') && newSettingsObj.password !== '') {
       device.log('try new password')
-	  passwordAttempt = 1
       let teslaSession = new Tesla({
         user: device.getStoreValue('username'),
         password: newSettingsObj.password
@@ -129,12 +127,9 @@ class Vehicle extends Homey.Device {
       await teslaSession.login().then(() => {
         device.log('tesla login success')
         reInit = true
-		passwordAttempt = 0
         device.logAvailable()
-		//return 
       }).catch(error => {
         device.log('tesla login error', error)
-		device.setUnavailable('Your Tesla is Unavailable, Invalid credentials.')
         throw new Error('Invalid password')
       })
     }
@@ -308,7 +303,6 @@ class Vehicle extends Homey.Device {
     const vehicleId = device.getStoreValue('vehicleId')
     if (!device.getAvailable()) return
     const wasMoving = vehicles[deviceId].moving
-    if (!device.getAvailable()) return
     let previousLocation = vehicles[deviceId].location || null
     let isMoving = null
     let driveState
@@ -341,7 +335,7 @@ class Vehicle extends Homey.Device {
     // if (!vehicles[deviceId].route.start) vehicles[deviceId].route = {id: vehicles[deviceId].routeCounter + 1, start: previousLocation}
     let distanceTraveled = (vehicles[deviceId].route.start && vehicles[deviceId].location.odometer) ? formatValue(vehicles[deviceId].location.odometer - vehicles[deviceId].route.start.odometer) : 0
 
-    device.log('trackLocation', {isMoving, distanceMovedSinceTrigger, timeSinceTrigger, distanceTraveled, passwordAttempt})
+    device.log('trackLocation', {isMoving, distanceMovedSinceTrigger, timeSinceTrigger, distanceTraveled})
 
     await device.logAvailable()
     await device.setCapabilityValue('location_human', driveState.place + ', ' + driveState.city)

--- a/drivers/ev/device.js
+++ b/drivers/ev/device.js
@@ -72,11 +72,13 @@ class Vehicle extends Homey.Device {
           device.trackController()
         }, device.getSetting('tokenRetryInterval') * 60 * 1000)
       } else {
-        device.log('Device unavailable due to invalid account / username / password')
-        device.setUnavailable(Homey.__('device.errorAccountAccess'))
-        let notification = new Homey.Notification({excerpt: Homey.__('device.errorAccountAccessNotification')})
-        await notification.register()
-        await device.trackController()
+        if (!device.getSetting('endlessRetries')) {
+          device.log('Device unavailable due to invalid account / username / password')
+          device.setUnavailable(Homey.__('device.errorAccountAccess'))
+          let notification = new Homey.Notification({excerpt: Homey.__('device.errorAccountAccessNotification')})
+          await notification.register()
+          await device.trackController()
+        }
       }
     })
     vehicles[deviceId].teslaApi.on('error', async reason => {

--- a/drivers/ev/device.js
+++ b/drivers/ev/device.js
@@ -36,7 +36,7 @@ class Vehicle extends Homey.Device {
     await device.setSettings({password: ''})
     await device.setAvailable()
     device.log('##### TESLA onInit #####', {Homey: Homey.version, App: Homey.manifest.version, Device: deviceId})
-	device.log('settings', device.getSettings())
+    device.log('settings', device.getSettings())
     vehicles[deviceId] = {
       id: deviceId,
       name: device.getName(),
@@ -127,7 +127,7 @@ class Vehicle extends Homey.Device {
       await teslaSession.login().then(() => {
         device.log('tesla login success')
         reInit = true
-        device.logAvailable()
+        return device.logAvailable()
       }).catch(error => {
         device.log('tesla login error', error)
         throw new Error('Invalid password')

--- a/drivers/ev/device.js
+++ b/drivers/ev/device.js
@@ -37,7 +37,6 @@ class Vehicle extends Homey.Device {
     await device.setSettings({password: ''})
     await device.setAvailable()
     device.log('##### TESLA onInit #####', {Homey: Homey.version, App: Homey.manifest.version, Device: deviceId})
-	device.log('Torstein Edition')
 	device.log('settings', device.getSettings())
     vehicles[deviceId] = {
       id: deviceId,


### PR DESCRIPTION
I have run this code on my LAB Homey for some time now, and this works.
The account does not get locked by hammering on the API.

This is just a button in the settings allowing for turning off the SetUnavail.

Set it as Opt In but this should probably just be default.

All other apps wording against this API does never stop due to api fails.